### PR TITLE
Exposed value_type for std::back_inserter support

### DIFF
--- a/.github/workflows/circularbuffer_build_pipeline.yml
+++ b/.github/workflows/circularbuffer_build_pipeline.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/circular_buffer.h
+++ b/circular_buffer.h
@@ -13,7 +13,6 @@ template<typename T>
 class CircularBuffer {
 private:
 	
-	typedef T value_type;
 	typedef T* pointer;
 	typedef const T* const_pointer;
 	typedef T& reference;
@@ -24,6 +23,8 @@ private:
 	
 
 public:
+    typedef T value_type;
+
 	explicit CircularBuffer(size_t size)
 		:_buff{std::unique_ptr<T[]>(new value_type[size])}, _max_size{size}{}
 


### PR DESCRIPTION
If `value_type` is exposed - it becomes possible to use the C++20 feature `std::back_inserter` on the circular buffer